### PR TITLE
feat: auto-updater integration with electron-updater

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { OpusEncoder } from './audio/opusEncoder'
 import { runMigrations } from './db/index'
 import { saveTranscription, getHistory, deleteTranscription, getHistoryCount } from './db/repository'
 import { createASRProvider, ASRProviderInterface } from './asr/providerFactory'
+import { initAutoUpdater, checkForUpdates, downloadUpdate, installUpdate } from './updater'
 
 // electron-store v10 ESM types don't resolve properly with moduleResolution: "node"
 const store = new Store() as unknown as { get(key: string, defaultValue?: unknown): unknown; set(key: string, value: unknown): void }
@@ -421,6 +422,18 @@ function setupIPC(): void {
     }
   })
 
+  ipcMain.handle(IPC_CHANNELS.CHECK_FOR_UPDATES, () => {
+    checkForUpdates()
+  })
+
+  ipcMain.handle(IPC_CHANNELS.DOWNLOAD_UPDATE, () => {
+    downloadUpdate()
+  })
+
+  ipcMain.handle(IPC_CHANNELS.INSTALL_UPDATE, () => {
+    installUpdate()
+  })
+
   ipcMain.handle(IPC_CHANNELS.ASR_STATUS, async () => {
     try {
       const { ASREngine } = await import('./asr/engine')
@@ -502,6 +515,13 @@ app.whenReady().then(async () => {
   createFloatingWidget()
   createMainWindow()
   registerGlobalShortcut()
+
+  // Initialize auto-updater (in production only)
+  if (!is.dev && mainWindow) {
+    initAutoUpdater(mainWindow)
+    // Check for updates 5 seconds after launch
+    setTimeout(() => checkForUpdates(), 5000)
+  }
 
   // Initialize AI engines in background
   initializeEngines().catch(console.error)

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,0 +1,72 @@
+import { autoUpdater } from 'electron-updater'
+import { BrowserWindow } from 'electron'
+import { IPC_CHANNELS } from '../shared/types'
+
+let mainWindow: BrowserWindow | null = null
+
+export function initAutoUpdater(window: BrowserWindow): void {
+  mainWindow = window
+
+  // Configure auto-updater
+  autoUpdater.autoDownload = false
+  autoUpdater.autoInstallOnAppQuit = true
+
+  // Log events
+  autoUpdater.on('checking-for-update', () => {
+    console.log('[Updater] Checking for updates...')
+  })
+
+  autoUpdater.on('update-available', (info) => {
+    console.log('[Updater] Update available:', info.version)
+    broadcastUpdate('update-available', {
+      version: info.version,
+      releaseDate: info.releaseDate,
+      releaseNotes: typeof info.releaseNotes === 'string' ? info.releaseNotes : ''
+    })
+  })
+
+  autoUpdater.on('update-not-available', () => {
+    console.log('[Updater] No updates available')
+    broadcastUpdate('update-not-available', {})
+  })
+
+  autoUpdater.on('download-progress', (progress) => {
+    broadcastUpdate('update-download-progress', {
+      percent: Math.round(progress.percent),
+      bytesPerSecond: progress.bytesPerSecond,
+      transferred: progress.transferred,
+      total: progress.total
+    })
+  })
+
+  autoUpdater.on('update-downloaded', (info) => {
+    console.log('[Updater] Update downloaded:', info.version)
+    broadcastUpdate('update-downloaded', { version: info.version })
+  })
+
+  autoUpdater.on('error', (error) => {
+    console.error('[Updater] Error:', error.message)
+  })
+}
+
+export function checkForUpdates(): void {
+  autoUpdater.checkForUpdates().catch((err) => {
+    console.error('[Updater] Check failed:', err.message)
+  })
+}
+
+export function downloadUpdate(): void {
+  autoUpdater.downloadUpdate().catch((err) => {
+    console.error('[Updater] Download failed:', err.message)
+  })
+}
+
+export function installUpdate(): void {
+  autoUpdater.quitAndInstall(false, true)
+}
+
+function broadcastUpdate(event: string, data: Record<string, unknown>): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(IPC_CHANNELS.UPDATE_STATUS, { event, ...data })
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,6 +60,18 @@ const api = {
       callback(state)
     ipcRenderer.on(IPC_CHANNELS.MODEL_DOWNLOAD_PROGRESS, listener)
     return () => ipcRenderer.removeListener(IPC_CHANNELS.MODEL_DOWNLOAD_PROGRESS, listener)
+  },
+
+  // Updates
+  checkForUpdates: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.CHECK_FOR_UPDATES),
+  downloadUpdate: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.DOWNLOAD_UPDATE),
+  installUpdate: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.INSTALL_UPDATE),
+
+  onUpdateStatus: (callback: (data: { event: string; version?: string; percent?: number }) => void): (() => void) => {
+    const listener = (_: Electron.IpcRendererEvent, data: { event: string; version?: string; percent?: number }): void =>
+      callback(data)
+    ipcRenderer.on(IPC_CHANNELS.UPDATE_STATUS, listener)
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.UPDATE_STATUS, listener)
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -199,5 +199,11 @@ export const IPC_CHANNELS = {
   TEST_ASR: 'asr:test',
 
   // ASR Status
-  ASR_STATUS: 'asr:status'
+  ASR_STATUS: 'asr:status',
+
+  // Updates
+  UPDATE_STATUS: 'update:status',
+  CHECK_FOR_UPDATES: 'update:check',
+  DOWNLOAD_UPDATE: 'update:download',
+  INSTALL_UPDATE: 'update:install'
 } as const


### PR DESCRIPTION
## Summary
- Add new `src/main/updater.ts` module that wraps `electron-updater` with event handling for checking, downloading, and installing updates
- Add IPC channels (`UPDATE_STATUS`, `CHECK_FOR_UPDATES`, `DOWNLOAD_UPDATE`, `INSTALL_UPDATE`) to shared types
- Wire up IPC handlers in main process and expose update APIs to the renderer via preload bridge
- Auto-updater initializes in production mode only, checking for updates 5 seconds after app launch

## Test plan
- [x] `npm run typecheck` passes clean
- [x] `npm test` -- all 153 tests pass
- [x] `npm run build` -- build succeeds
- [ ] Manual: verify update check triggers in packaged production build
- [ ] Manual: verify update download progress is broadcast to renderer
- [ ] Manual: verify quit-and-install flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)