### PR TITLE
feat: add hotkey conflict detection with fallback alternatives

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,13 @@ import { saveTranscription, getHistory, deleteTranscription, getHistoryCount } f
 import { createASRProvider, ASRProviderInterface } from './asr/providerFactory'
 import { initAutoUpdater, checkForUpdates, downloadUpdate, installUpdate } from './updater'
 
+const ALTERNATIVE_HOTKEYS = [
+  'CommandOrControl+Shift+Space',
+  'CommandOrControl+Shift+S',
+  'CommandOrControl+Alt+Space',
+  'CommandOrControl+Shift+R'
+]
+
 // electron-store v10 ESM types don't resolve properly with moduleResolution: "node"
 const store = new Store() as unknown as { get(key: string, defaultValue?: unknown): unknown; set(key: string, value: unknown): void }
 
@@ -232,7 +239,7 @@ function updateTrayMenu(): void {
 function registerGlobalShortcut(): void {
   globalShortcut.unregisterAll()
 
-  const registered = globalShortcut.register(settings.globalHotkey, async () => {
+  const hotkeyCallback = async (): Promise<void> => {
     if (audioCapture?.isRecording) {
       await stopRecording()
     } else {
@@ -247,11 +254,38 @@ function registerGlobalShortcut(): void {
         }, 30000) // 30 second max
       }
     }
-  })
-
-  if (!registered) {
-    console.error('Failed to register global shortcut:', settings.globalHotkey)
   }
+
+  const registered = globalShortcut.register(settings.globalHotkey, hotkeyCallback)
+
+  if (registered) {
+    broadcastToRenderers(IPC_CHANNELS.HOTKEY_STATUS, {
+      registered: true,
+      hotkey: settings.globalHotkey
+    })
+    return
+  }
+
+  console.error('Failed to register global shortcut:', settings.globalHotkey)
+
+  // Try alternative hotkeys
+  let fallbackHotkey: string | null = null
+  for (const alt of ALTERNATIVE_HOTKEYS) {
+    if (alt === settings.globalHotkey) continue
+    if (globalShortcut.register(alt, hotkeyCallback)) {
+      fallbackHotkey = alt
+      break
+    }
+  }
+
+  broadcastToRenderers(IPC_CHANNELS.HOTKEY_STATUS, {
+    registered: false,
+    hotkey: settings.globalHotkey,
+    error: fallbackHotkey
+      ? `"${settings.globalHotkey}" unavailable. Using "${fallbackHotkey}" instead.`
+      : 'Hotkey is in use by another app. Change it in Settings.',
+    fallback: fallbackHotkey ?? undefined
+  })
 }
 
 async function initializeEngines(): Promise<void> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -67,6 +67,13 @@ const api = {
   downloadUpdate: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.DOWNLOAD_UPDATE),
   installUpdate: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.INSTALL_UPDATE),
 
+  onHotkeyStatus: (callback: (data: { registered: boolean; hotkey: string; error?: string }) => void): (() => void) => {
+    const listener = (_: Electron.IpcRendererEvent, data: { registered: boolean; hotkey: string; error?: string }): void =>
+      callback(data)
+    ipcRenderer.on(IPC_CHANNELS.HOTKEY_STATUS, listener)
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.HOTKEY_STATUS, listener)
+  },
+
   onUpdateStatus: (callback: (data: { event: string; version?: string; percent?: number }) => void): (() => void) => {
     const listener = (_: Electron.IpcRendererEvent, data: { event: string; version?: string; percent?: number }): void =>
       callback(data)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -43,6 +43,20 @@ function App(): JSX.Element {
     return unsubscribe
   }, [loadHistory])
 
+  // Notify on hotkey conflict
+  useEffect(() => {
+    if (!window.api?.onHotkeyStatus) return
+    const unsubscribe = window.api.onHotkeyStatus((data) => {
+      if (!data.registered) {
+        enqueueSnackbar(
+          `Hotkey "${data.hotkey}" is unavailable. ${data.error || 'Try a different shortcut.'}`,
+          { variant: 'warning', autoHideDuration: 8000 }
+        )
+      }
+    })
+    return unsubscribe
+  }, [])
+
   // Notify on model download completion or errors
   useEffect(() => {
     if (!window.api?.onModelDownloadProgress) return

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -209,5 +209,8 @@ export const IPC_CHANNELS = {
   UPDATE_STATUS: 'update:status',
   CHECK_FOR_UPDATES: 'update:check',
   DOWNLOAD_UPDATE: 'update:download',
-  INSTALL_UPDATE: 'update:install'
+  INSTALL_UPDATE: 'update:install',
+
+  // Hotkey
+  HOTKEY_STATUS: 'hotkey:status'
 } as const


### PR DESCRIPTION
## Summary
- When global hotkey registration fails (e.g. another app is using the same shortcut), the app now detects the conflict and tries alternative hotkey combinations (`CommandOrControl+Shift+S`, `CommandOrControl+Alt+Space`, `CommandOrControl+Shift+R`) as fallbacks
- Broadcasts hotkey registration status to the renderer via a new `HOTKEY_STATUS` IPC channel
- Shows a warning snackbar notification in the UI when the configured hotkey is unavailable, including information about which fallback was used (if any)

## Changes
- `src/shared/types.ts`: Added `HOTKEY_STATUS` IPC channel
- `src/main/index.ts`: Refactored `registerGlobalShortcut()` to extract callback, try fallback hotkeys on failure, and broadcast status via IPC. Added `ALTERNATIVE_HOTKEYS` constant.
- `src/preload/index.ts`: Added `onHotkeyStatus` listener to the preload API
- `src/renderer/src/App.tsx`: Added `useEffect` to listen for hotkey status and display warning snackbar on conflict

## Test plan
- [ ] Verify hotkey registration works normally when no conflict exists
- [ ] Simulate a hotkey conflict (e.g. register the same shortcut in another app) and verify the fallback mechanism activates
- [ ] Verify the warning snackbar appears with the correct message when a conflict is detected
- [ ] Verify the snackbar shows which alternative hotkey was used as fallback
- [ ] Verify that changing the hotkey in Settings re-triggers registration and status broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)