### PR TITLE
feat: add history export (CSV/JSON) and custom prompt mode editor

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -472,6 +472,22 @@ function setupIPC(): void {
     return getHistoryCount()
   })
 
+  ipcMain.handle(IPC_CHANNELS.EXPORT_HISTORY, async (_, format: 'csv' | 'json') => {
+    const items = getHistory(10000) // Get all history
+    if (format === 'json') {
+      return JSON.stringify(items, null, 2)
+    }
+    // CSV format
+    const headers = 'id,rawText,refinedText,duration,createdAt\n'
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = (items as any[]).map(item => {
+      const raw = (item.rawText || '').replace(/"/g, '""')
+      const refined = (item.refinedText || '').replace(/"/g, '""')
+      return `"${item.id}","${raw}","${refined}",${item.duration || 0},"${item.createdAt || ''}"`
+    }).join('\n')
+    return headers + rows
+  })
+
   ipcMain.handle(IPC_CHANNELS.ONBOARDING_COMPLETE, () => {
     store.set('onboardingComplete', true)
     onboardingWindow?.close()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,6 +25,8 @@ const api = {
     ipcRenderer.invoke(IPC_CHANNELS.DELETE_HISTORY, id),
   getHistoryCount: () =>
     ipcRenderer.invoke(IPC_CHANNELS.GET_HISTORY_COUNT),
+  exportHistory: (format: 'csv' | 'json'): Promise<string> =>
+    ipcRenderer.invoke(IPC_CHANNELS.EXPORT_HISTORY, format),
 
   // Onboarding
   completeOnboarding: (): Promise<void> =>

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -283,6 +283,66 @@ export function SettingsPanel({ settings, onChange }: SettingsPanelProps): JSX.E
       </div>
 
       <div className="card">
+        <h3 className="card-title">Custom Writing Modes</h3>
+
+        {(settings.customPromptModes || []).map((mode, index) => (
+          <div key={mode.id} className="custom-prompt-item">
+            <div className="custom-prompt-header">
+              <input
+                type="text"
+                value={mode.name}
+                onChange={(e) => {
+                  const updated = [...(settings.customPromptModes || [])]
+                  updated[index] = { ...updated[index], name: e.target.value }
+                  onChange({ customPromptModes: updated })
+                }}
+                placeholder="Mode name"
+              />
+              <button
+                className={`mode-button ${settings.promptMode === mode.id ? 'active' : ''}`}
+                onClick={() => onChange({ promptMode: mode.id })}
+              >
+                Use
+              </button>
+              <button
+                className="delete-btn"
+                onClick={() => {
+                  const updated = (settings.customPromptModes || []).filter((_, i) => i !== index)
+                  onChange({ customPromptModes: updated })
+                }}
+              >
+                {'\u2715'}
+              </button>
+            </div>
+            <textarea
+              value={mode.systemPrompt}
+              onChange={(e) => {
+                const updated = [...(settings.customPromptModes || [])]
+                updated[index] = { ...updated[index], systemPrompt: e.target.value }
+                onChange({ customPromptModes: updated })
+              }}
+              placeholder="System prompt..."
+              rows={4}
+            />
+          </div>
+        ))}
+
+        <button
+          className="add-prompt-btn"
+          onClick={() => {
+            const newMode = {
+              id: `custom-${Date.now()}`,
+              name: 'New Mode',
+              systemPrompt: 'You are a helpful assistant. Rewrite the following speech transcript:\n\nGuidelines:\n- Remove filler words\n- Fix grammar\n- Output only the rewritten text'
+            }
+            onChange({ customPromptModes: [...(settings.customPromptModes || []), newMode] })
+          }}
+        >
+          + Add Custom Mode
+        </button>
+      </div>
+
+      <div className="card">
         <h3 className="card-title">Model Profile</h3>
 
         <div className="profile-selector">

--- a/src/renderer/src/components/TranscriptionHistory.tsx
+++ b/src/renderer/src/components/TranscriptionHistory.tsx
@@ -57,6 +57,18 @@ export function TranscriptionHistory({
     overscan: 5
   })
 
+  const handleExport = async (format: 'csv' | 'json'): Promise<void> => {
+    if (!window.api?.exportHistory) return
+    const data = await window.api.exportHistory(format)
+    const blob = new Blob([data], { type: format === 'json' ? 'application/json' : 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `transcriptions.${format}`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
   if (history.length === 0) {
     return (
       <div className="transcription-history empty">
@@ -80,7 +92,13 @@ export function TranscriptionHistory({
 
   return (
     <div className="transcription-history">
-      <h3>Recent Transcriptions</h3>
+      <div className="history-header-row">
+        <h3>Recent Transcriptions</h3>
+        <div className="history-export-buttons">
+          <button className="export-btn" onClick={() => handleExport('json')} title="Export as JSON">JSON</button>
+          <button className="export-btn" onClick={() => handleExport('csv')} title="Export as CSV">CSV</button>
+        </div>
+      </div>
       <div ref={parentRef} className="history-list" style={{ height: '400px', overflow: 'auto' }}>
         <div
           style={{

--- a/src/renderer/src/styles/global.css
+++ b/src/renderer/src/styles/global.css
@@ -1090,3 +1090,101 @@ body {
   color: var(--text-secondary);
   margin-top: 4px;
 }
+
+/* ========== Export Buttons ========== */
+.history-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.history-export-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.export-btn {
+  padding: 4px 12px;
+  font-size: 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-family: inherit;
+}
+
+.export-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ========== Custom Prompt Editor ========== */
+.custom-prompt-item {
+  margin-bottom: 12px;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.custom-prompt-header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.custom-prompt-header input[type='text'] {
+  flex: 1;
+  padding: 6px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.custom-prompt-header input[type='text']:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.custom-prompt-item textarea {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  resize: vertical;
+  line-height: 1.4;
+}
+
+.custom-prompt-item textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.add-prompt-btn {
+  width: 100%;
+  padding: 10px;
+  background: var(--bg-primary);
+  border: 2px dashed var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+  transition: all var(--transition-fast);
+}
+
+.add-prompt-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/src/shared/types.test.ts
+++ b/src/shared/types.test.ts
@@ -36,6 +36,10 @@ describe('types', () => {
       expect(DEFAULT_SETTINGS.hotkeyMode).toBe('toggle')
     })
 
+    it('should have customPromptModes default as empty array', () => {
+      expect(DEFAULT_SETTINGS.customPromptModes).toEqual([])
+    })
+
     it('should have valid hotkey format', () => {
       const hotkey = DEFAULT_SETTINGS.globalHotkey
       expect(hotkey).toMatch(/^[A-Za-z+]+$/)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -135,6 +135,12 @@ Guidelines:
   }
 ]
 
+export interface CustomPromptMode {
+  id: string
+  name: string
+  systemPrompt: string
+}
+
 export interface AppSettings {
   globalHotkey: string
   hotkeyMode: HotkeyMode
@@ -145,6 +151,7 @@ export interface AppSettings {
   enableSounds: boolean
   asrProvider: ASRProvider
   cloudApiConfig: CloudAPIConfig
+  customPromptModes: CustomPromptMode[]
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -156,7 +163,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   modelProfileId: 'balanced',
   enableSounds: true,
   asrProvider: 'local-whisper',
-  cloudApiConfig: {}
+  cloudApiConfig: {},
+  customPromptModes: []
 }
 
 // IPC Channel names
@@ -209,5 +217,11 @@ export const IPC_CHANNELS = {
   UPDATE_STATUS: 'update:status',
   CHECK_FOR_UPDATES: 'update:check',
   DOWNLOAD_UPDATE: 'update:download',
-  INSTALL_UPDATE: 'update:install'
+  INSTALL_UPDATE: 'update:install',
+
+  // Hotkey
+  HOTKEY_STATUS: 'hotkey:status',
+
+  // Export
+  EXPORT_HISTORY: 'history:export'
 } as const


### PR DESCRIPTION
## Summary
- Add export transcription history as CSV or JSON via new IPC channel and UI buttons in the history header
- Add custom prompt mode editor in the Settings panel with ability to create, edit, delete, and activate custom writing modes
- Add `CustomPromptMode` interface and `customPromptModes` field to `AppSettings` with proper defaults

## Test plan
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] All 155 tests pass (`npm test`), including new test for `customPromptModes` default
- [x] Build succeeds (`npm run build`)
- [ ] Manual: Verify export buttons (JSON/CSV) appear in transcription history header and produce correct downloads
- [ ] Manual: Verify custom prompt editor appears in Settings, supports add/edit/delete/use actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)